### PR TITLE
Add motion options for falling piece

### DIFF
--- a/src/pages/ConnectPlay.tsx
+++ b/src/pages/ConnectPlay.tsx
@@ -134,7 +134,9 @@ const Board: React.FC<BoardProps> = ({ player, game, placePiece }) => {
                             className={classNames(
                                 'w-full aspect-square rounded-full',
                                 piece === '1' ? 'bg-red-500' : 'bg-yellow-500',
-                                columnIndex === game.lastColumn ? 'last:animate-fall' : '',
+                                columnIndex === game.lastColumn
+                                    ? 'last:animate-fall last:motion-safe:animate-fall last:motion-reduce:animate-none'
+                                    : '',
                             )}
                         />
                     ))}


### PR DESCRIPTION
On iOS Chrome, motion of falling piece was choppy. This is an attempt to fix it.